### PR TITLE
Add support for JUnit's @Ignore annotation

### DIFF
--- a/jdave-core/src/java/jdave/runner/DefaultSpecIntrospection.java
+++ b/jdave-core/src/java/jdave/runner/DefaultSpecIntrospection.java
@@ -15,6 +15,8 @@
  */
 package jdave.runner;
 
+import org.junit.Ignore;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
@@ -39,6 +41,9 @@ public class DefaultSpecIntrospection implements ISpecIntrospection {
             return false;
         }
         if (method.getParameterTypes().length > 0) {
+            return false;
+        }
+        if (method.getAnnotation(Ignore.class) != null) {
             return false;
         }
         return true;

--- a/jdave-core/src/test/jdave/runner/SpecRunnerTest.java
+++ b/jdave-core/src/test/jdave/runner/SpecRunnerTest.java
@@ -234,6 +234,11 @@ public class SpecRunnerTest {
                 actualCalls.add("methodWhichTakesParameters");
             }
 
+            @Ignore(value = "this should not be called")
+            public void ignoredMethod() {
+                actualCalls.add("ignoredMethod");
+            }
+
             public void destroy() {
                 destroyCalled++;
             }


### PR DESCRIPTION
Added support for JUnit's @Ignore annotation http://junit.sourceforge.net/javadoc/org/junit/Ignore.html. Methods with @Ignore annotation are skipped by the test runners.
