### PR TITLE
Upgrade maven-plugin-plugin to version 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,10 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
           </configuration>
         </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.9</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Eclipse m2 plugin does not find all dependencies for maven-plugin-plugin 2.6, and complains about jdave-report-plugin, so upgrading maven-plugin-plugin to version 2.9.
