### PR TITLE
preserve stacktrace when serialization fail

### DIFF
--- a/jdave-core/src/java/jdave/contract/SerializableContract.java
+++ b/jdave-core/src/java/jdave/contract/SerializableContract.java
@@ -40,7 +40,7 @@ public class SerializableContract implements IContract {
         try {
             stream.writeObject(obj);
         } catch (IOException e) {
-            throw new ExpectationFailedException(obj + " is not serializable");
+            throw new ExpectationFailedException(obj + " is not serializable", e);
         } finally {
             try {
                 stream.close();


### PR DESCRIPTION
When checking that A is serializable and someone add a property of non-serializable type B in A, without preserving the statcktrace, you only know that A is not serializable anymore. 

With the extra cause, you know that's because B is not serializable.

It's a minor tweak but it helps fix the issues faster.
