### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jdave/JDave.png)](https://travis-ci.org/jdave/JDave)
+
 [JDave][1] is a BDD framework for Java. It is inspired by rspec and integrates JMock 2 as mocking framework and Hamcrest as matching library. It uses JUnit adapter to launch JDave specifications.
 
 [1]: http://jdave.org/


### PR DESCRIPTION
Implements integration with Travis CI, which is a very handy distributed continuous integration service.  Here I've enabled builds & tests to run for OpenJDK 6/7 & OracleJDK 7. @jdave, I believe you'll need to do the following to activate Travis CI for this project:
- Login with GitHub into https://travis-ci.org/
- Go to https://travis-ci.org/profile and activate the on/off switch for JDave
- Merge this pull request into master

That's it. The first built will be triggered by your next push to repo and you'll get notifications if any of your pushed builds fail from here on.
